### PR TITLE
Spelling correction for ES6/10 - When NOT to use an Arrow Function

### DIFF
--- a/ES6/10 - When NOT to use an Arrow Function.txt
+++ b/ES6/10 - When NOT to use an Arrow Function.txt
@@ -16,15 +16,15 @@ Instructor: [00:02] Before you start going bananas on using arrow functions, let
 
 [02:34] Now, we're going to go into a little bit more, but let's just look ahead. We could have also used that. That is equivalent to just a regular type "dot function," not an arrow function.
 
-[02:45] Next up, we have this, when you need to add a prototype method. Here, I've got a class. We haven't learned about classes, but just know that this is a way for us to make new cars. I have this class constructor where, when you call "new Car," we pass it the type of Car, as well as the color of the Car. I can say the bima is a BMW that is blue. The subie is a Subaru that is white.
+[02:45] Next up, we have this, when you need to add a prototype method. Here, I've got a class. We haven't learned about classes, but just know that this is a way for us to make new cars. I have this class constructor where, when you call "new Car," we pass it the type of Car, as well as the color of the Car. I can say the beemer is a BMW that is blue. The subie is a Subaru that is white.
 
-[03:10] Let's go ahead and look at them. I'll say subie, there we go, is a Subaru that's white. A bima is a BMW that's blue. Now, after the fact, I added on this prototype method, and what that allows us to do is that, even after these things have been created, we can add methods onto all of them. I say car.prototype.summarize, which will allow me to do things like subie.summarize.
+[03:10] Let's go ahead and look at them. I'll say subie, there we go, is a Subaru that's white. A beemer is a BMW that's blue. Now, after the fact, I added on this prototype method, and what that allows us to do is that, even after these things have been created, we can add methods onto all of them. I say car.prototype.summarize, which will allow me to do things like subie.summarize.
 
 [03:37] You see that it's auto-completing it there, because it's available to me. Even though I added it after we created the Car, because I added it to the prototype, it's available in every object that has been created from there. What this prototype does is it returns "this.make" which is the make that we passed in, and "this.color," in a sentence.
 
 [03:57] But when you call it, "this.car" is undefined and the color undefined. Why is that? It's because we try to be cool. We try to be a bit of a hot shot here by using an arrow function. Again, why don't we use an arrow function here? Because we explicitly need the keyword "this," so a regular function would do. Give that a save.
 
-[04:17] Now, if we call subie.summarize, it says it's a white. We call bima.summarize, we get BMW in blue. Again, using a regular function for that. Then, finally, this is a little bit different. It doesn't have to do with the keyword "this," but we don't have access to the Arguments object when you use an arrow function.
+[04:17] Now, if we call subie.summarize, it says it's a white. We call beemer.summarize, we get BMW in blue. Again, using a regular function for that. Then, finally, this is a little bit different. It doesn't have to do with the keyword "this," but we don't have access to the Arguments object when you use an arrow function.
 
 [04:39] This is helpful for when you want to run a function like, right here, this function is going to take unlimited arguments. It might take one, it might take 100. It's going to just say like, "This child was born first." Here's an example, older children, I'm passing in, "Jill" as a first argument, "Wes" as a second argument, and "Jana" as a third argument.
 

--- a/ES6/10 - When NOT to use an Arrow Function.txt
+++ b/ES6/10 - When NOT to use an Arrow Function.txt
@@ -26,7 +26,7 @@ Instructor: [00:02] Before you start going bananas on using arrow functions, let
 
 [04:17] Now, if we call subie.summarize, it says it's a white. We call beemer.summarize, we get BMW in blue. Again, using a regular function for that. Then, finally, this is a little bit different. It doesn't have to do with the keyword "this," but we don't have access to the Arguments object when you use an arrow function.
 
-[04:39] This is helpful for when you want to run a function like, right here, this function is going to take unlimited arguments. It might take one, it might take 100. It's going to just say like, "This child was born first." Here's an example, older children, I'm passing in, "Jill" as a first argument, "Wes" as a second argument, and "Jana" as a third argument.
+[04:39] This is helpful for when you want to run a function like, right here, this function is going to take unlimited arguments. It might take one, it might take 100. It's going to just say like, "This child was born first." Here's an example, older children, I'm passing in, "Jill" as a first argument, "Wes" as a second argument, and "Jenna" as a third argument.
 
 [04:59] When I run it, it says, "ReferenceError, arguments is not defined." Arguments is a keyword that we have in JavaScript that's going to give us an array or array-ish value of everything that was passed in. One, two, three items, and you do not get the Arguments object if you use an arrow function when you use a regular function, which is going to give us the actual content that we need.
 

--- a/ES6/10 - When NOT to use an Arrow Function.vtt
+++ b/ES6/10 - When NOT to use an Arrow Function.vtt
@@ -614,7 +614,7 @@ as a first argument, "Wes" as a
 
 154
 00:04:57.705 --> 00:04:58.670
-second argument, and "Jana" as a 
+second argument, and "Jenna" as a 
 
 155
 00:04:58.730 --> 00:05:00.410

--- a/ES6/10 - When NOT to use an Arrow Function.vtt
+++ b/ES6/10 - When NOT to use an Arrow Function.vtt
@@ -382,7 +382,7 @@ color of the Car. I can say the
 
 96
 00:03:05.130 --> 00:03:08.430
-bima is a BMW that is blue. The 
+beemer is a BMW that is blue. The 
 
 97
 00:03:08.505 --> 00:03:10.150
@@ -398,7 +398,7 @@ I'll say subie, there we go, is
 
 100
 00:03:15.645 --> 00:03:20.260
-a Subaru that's white. A bima is 
+a Subaru that's white. A beemer is 
 
 101
 00:03:20.270 --> 00:03:22.270
@@ -538,7 +538,7 @@ summarize, it says it's a white.
 
 135
 00:04:22.360 --> 00:04:25.060
-We call bima.summarize, we get 
+We call beemer.summarize, we get 
 
 136
 00:04:25.070 --> 00:04:27.880


### PR DESCRIPTION
Correct "bima" to "beemer" to correctly match the variable name being used.