### PR TITLE
Change references to text editor Adam -> Atom

### DIFF
--- a/NODE/01 - Getting Setup.vtt
+++ b/NODE/01 - Getting Setup.vtt
@@ -204,7 +204,7 @@ highlighter. If you are in Visual Studio
 
 00:03:51.300 --> 00:03:55.630 line:100% position:50% align:middle
 Code, it comes default. You don't need to
-install anything. If you are in Adam,
+install anything. If you are in Atom,
 
 00:03:55.630 --> 00:03:59.520 line:100% position:50% align:middle
 there is one called language-jade,
@@ -240,7 +240,7 @@ have it, make sure you go grab that from
 
 00:04:29.130 --> 00:04:33.770 line:100% position:50% align:middle
 package control. The ones in Visual Studio
-Code and Adam are already up to date,
+Code and Atom are already up to date,
 
 00:04:33.770 --> 00:04:39.030 line:100% position:50% align:middle
 so there's no need to install any new


### PR DESCRIPTION
Looks like transcriber misheard the name of Atom.app as Adam. Fixed 2 occurrences.