### PR TITLE
typo: nvm run build -> npm run build

### DIFF
--- a/RFB/25 - Building React for Production.vtt
+++ b/RFB/25 - Building React for Production.vtt
@@ -24,7 +24,7 @@ script called build and we simply just
 have to run. If you open up your terminal
 
 00:00:29.260 --> 00:00:34.880 line:100% position:50% align:middle
-here, nvm run build, and what that's going
+here, npm run build, and what that's going
 to do is it's going to compress it,
 
 00:00:34.880 --> 00:00:38.940 line:100% position:50% align:middle


### PR DESCRIPTION
Video shows "npm", not "nvm".