### PR TITLE
Abbrevation Fix 'APBR' to 'ABBR'

### DIFF
--- a/ES6/15 - Tagged Templates Exercise.txt
+++ b/ES6/15 - Tagged Templates Exercise.txt
@@ -10,11 +10,11 @@ Wes: [00:02] Here's another example of when tag templates could come in handy. I
 
 [01:44] I'm going to make a function here called "add abbreviations." I copy paste it there, so I do not know how to spell abbreviation. In this, so it's going to be a little bit different than the last one that we did. I want to make a new array of, not just of values, because the values are going to give me "Wes," "Boss," "HTML," "CSS," and "JS."
 
-[02:06] I want an array of values that, if there's an abbreviation, I want them wrapped in an APBR tag. What I'm going to say is const abbreviated. I'm going to take the regular values and map over them, and return a new array of the values. We'll say for each value...now we're going to check if there is a value in the dictionary.
+[02:06] I want an array of values that, if there's an abbreviation, I want them wrapped in an ABBR tag. What I'm going to say is const abbreviated. I'm going to take the regular values and map over them, and return a new array of the values. We'll say for each value...now we're going to check if there is a value in the dictionary.
 
 [02:32] We'll say if the dictionary has an item for that specific value, so if there's a value of "Wes," is there's going to be a value of "Wes?" No, there's not. It's just going to skip over that. Is there a value of "HTML?" If the dictionary has an "HTML" key, oh yes there is, there is one. We're just using a variable there.
 
-[02:54] If that is true then, we are going to return the abbreviation tag, which is "APBR," and the title of that abbreviation tag is going to be the dictionary item with that key of "HTML, CSS or JS." Then inside of the abbreviation tag, we are going to return the value there. What that's going to give us if we console.log the abbreviated values here, and we take that tag template, pop it on to here.
+[02:54] If that is true then, we are going to return the abbreviation tag, which is "ABBR," and the title of that abbreviation tag is going to be the dictionary item with that key of "HTML, CSS or JS." Then inside of the abbreviation tag, we are going to return the value there. What that's going to give us if we console.log the abbreviated values here, and we take that tag template, pop it on to here.
 
 [03:26] You'll see we get undefined, undefined. Why do we get undefined, undefined? That's Wes and Boss, what I forgot to do here. Otherwise, we just want to return the value. If it's not in the dictionary, it's just a regular variable. We're going to skip over that, but we still need to return it into the actual variable there. Here we go. "Wes Boss."
 

--- a/ES6/15 - Tagged Templates Exercise.vtt
+++ b/ES6/15 - Tagged Templates Exercise.vtt
@@ -234,7 +234,7 @@ there's an abbreviation, I want
 
 59
 00:02:11.570 --> 00:02:13.740
-them wrapped in an APBR tag. 
+them wrapped in an ABBR tag. 
 
 60
 00:02:13.815 --> 00:02:16.130
@@ -318,7 +318,7 @@ return the abbreviation tag,
 
 80
 00:02:58.575 --> 00:03:01.800
-which is "APBR," and the title 
+which is "ABBR," and the title 
 
 81
 00:03:01.810 --> 00:03:03.160


### PR DESCRIPTION
In ES6, Excercise 15: Tagged Templates Exercise captions said APBR instead of ABBR